### PR TITLE
Load video from device to android project

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 
     // jetpack compose
     implementation("androidx.activity:activity-compose:1.8.0")
+    implementation("androidx.activity:activity-ktx:1.8.0")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
@@ -86,6 +87,7 @@ dependencies {
     // jetpack compose extended icons
     implementation("androidx.compose.material:material-icons-extended:1.5.4")
 
+    // test tools
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -107,6 +107,10 @@ dependencies {
     // Retrofit
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
+    // Media3
+    implementation("androidx.media3:media3-exoplayer:1.1.1")
+    implementation("androidx.media3:media3-ui:1.1.1")
 }
 
 // Allow references to generated code (hilt)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-    <uses-permission android:name="android.permission.WRITE_MEDIA_VIDEO"/>
-
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application

--- a/android/app/src/main/java/com/goliath/emojihub/NavigationDestination.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/NavigationDestination.kt
@@ -1,0 +1,5 @@
+package com.goliath.emojihub
+
+object NavigationDestination {
+    const val TransformVideo = "transform_video"
+}

--- a/android/app/src/main/java/com/goliath/emojihub/RootActivity.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/RootActivity.kt
@@ -14,20 +14,26 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.goliath.emojihub.ui.theme.EmojiHubTheme
 import com.goliath.emojihub.viewmodels.UserViewModel
 import com.goliath.emojihub.views.BottomNavigationBar
 import com.goliath.emojihub.views.LoginPage
-import com.goliath.emojihub.views.SignUpPage
 import com.goliath.emojihub.views.pageItemList
 import dagger.hilt.android.AndroidEntryPoint
+
+val LocalNavController = compositionLocalOf<NavController> {
+    throw RuntimeException("")
+}
 
 @AndroidEntryPoint
 class RootActivity : ComponentActivity() {
@@ -60,36 +66,41 @@ class RootActivity : ComponentActivity() {
 @Composable
 fun RootView(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
-    Scaffold(
-        bottomBar =  {
-            BottomNavigation(
-                backgroundColor = Color.White
-            ) {
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentRoute = navBackStackEntry?.destination?.route
-                pageItemList.forEach { pageItem ->
-                    BottomNavigationItem(
-                        selected = currentRoute == pageItem.screenRoute,
-                        onClick = { navController.navigate(pageItem.screenRoute) {
-                            navController.graph.startDestinationRoute?.let {
-                                popUpTo(it) { saveState = true }
+
+    CompositionLocalProvider(
+        LocalNavController provides navController
+    ) {
+        Scaffold(
+            bottomBar =  {
+                BottomNavigation(
+                    backgroundColor = Color.White
+                ) {
+                    val navBackStackEntry by navController.currentBackStackEntryAsState()
+                    val currentRoute = navBackStackEntry?.destination?.route
+                    pageItemList.forEach { pageItem ->
+                        BottomNavigationItem(
+                            selected = currentRoute == pageItem.screenRoute,
+                            onClick = { navController.navigate(pageItem.screenRoute) {
+                                navController.graph.startDestinationRoute?.let {
+                                    popUpTo(it) { saveState = true }
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            } },
+                            icon = {
+                                Icon(
+                                    painter = painterResource(id = pageItem.icon),
+                                    contentDescription = "",
+                                    tint = if (currentRoute == pageItem.screenRoute) Color.Black else Color.LightGray)
                             }
-                            launchSingleTop = true
-                            restoreState = true
-                        } },
-                        icon = {
-                            Icon(
-                                painter = painterResource(id = pageItem.icon),
-                                contentDescription = "",
-                                tint = if (currentRoute == pageItem.screenRoute) Color.Black else Color.LightGray)
-                        }
-                    )
+                        )
+                    }
                 }
             }
-        }
-    ) {
-        Box(Modifier.padding(it)) {
-            BottomNavigationBar(navController = navController)
+        ) {
+            Box(Modifier.padding(it)) {
+                BottomNavigationBar(navController = navController)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/repositories/remote/EmojiRepository.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/repositories/remote/EmojiRepository.kt
@@ -1,5 +1,6 @@
 package com.goliath.emojihub.repositories.remote
 
+import com.goliath.emojihub.data_sources.UserApi
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -9,7 +10,8 @@ interface EmojiRepository {
 
 @Singleton
 class EmojiRepositoryImpl @Inject constructor(
-
+    // added temporarily for building project. will be soon replaced by `EmojiApi`
+    private val userApi: UserApi
 ): EmojiRepository {
     override fun fetchEmojiList() {
         TODO("Not yet implemented")

--- a/android/app/src/main/java/com/goliath/emojihub/viewmodels/EmojiViewModel.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/viewmodels/EmojiViewModel.kt
@@ -1,5 +1,6 @@
 package com.goliath.emojihub.viewmodels
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.goliath.emojihub.usecases.EmojiUseCase
 import com.goliath.emojihub.views.PageItem
@@ -14,4 +15,6 @@ class EmojiViewModel @Inject constructor(
 ): ViewModel() {
     private val _emojiState = MutableStateFlow<PageItem.Emoji?>(null)
     val emojiState = _emojiState.asStateFlow()
+
+    var videoUri: Uri = Uri.EMPTY
 }

--- a/android/app/src/main/java/com/goliath/emojihub/views/BottomNavigationBar.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/BottomNavigationBar.kt
@@ -1,11 +1,15 @@
 package com.goliath.emojihub.views
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.goliath.emojihub.NavigationDestination
 import com.goliath.emojihub.R
 import com.goliath.emojihub.models.dummyPost
+import com.goliath.emojihub.viewmodels.EmojiViewModel
 
 @Composable
 fun BottomNavigationBar(
@@ -22,6 +26,14 @@ fun BottomNavigationBar(
 
         composable(PageItem.Profile.screenRoute) {
             ProfilePage()
+        }
+
+        composable(NavigationDestination.TransformVideo) {
+            val parentEntry = remember(it) {
+                navController.getBackStackEntry(PageItem.Emoji.screenRoute)
+            }
+            val emojiViewModel = hiltViewModel<EmojiViewModel>(parentEntry)
+            TransformVideoPage(emojiViewModel)
         }
     }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
@@ -1,9 +1,66 @@
 package com.goliath.emojihub.views
 
+import android.content.Intent
+import android.provider.MediaStore
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.app.ActivityCompat.startActivityForResult
+import com.goliath.emojihub.ui.theme.Color
+
 
 @Composable
 fun EmojiPage() {
-    Text(text = "Emoji")
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            Button(
+                onClick = {
+                    // TODO: implement
+                },
+                modifier = Modifier
+                    .padding(top = 24.dp)
+                    .fillMaxWidth()
+                    .height(44.dp),
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Black,
+                    contentColor = Color.White
+                )
+            ) {
+                Text(
+                    text = "영상 업로드",
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EmojiPagePreview() {
+    EmojiPage()
 }

--- a/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
@@ -1,7 +1,13 @@
 package com.goliath.emojihub.views
 
-import android.content.Intent
-import android.provider.MediaStore
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,16 +21,28 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.app.ActivityCompat.startActivityForResult
+import androidx.core.content.ContextCompat
 import com.goliath.emojihub.ui.theme.Color
-
 
 @Composable
 fun EmojiPage() {
+    val context = LocalContext.current
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {}
+
+    val pickMediaLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        uri.let { Log.d("PhotoPicker", "Selected URI: $uri") }
+    }
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -36,7 +54,20 @@ fun EmojiPage() {
         ) {
             Button(
                 onClick = {
-                    // TODO: implement
+                    when (PackageManager.PERMISSION_GRANTED) {
+                        ContextCompat.checkSelfPermission(
+                            context, Manifest.permission.READ_MEDIA_VIDEO
+                        ) -> {
+                            pickMediaLauncher.launch(PickVisualMediaRequest(
+                                ActivityResultContracts.PickVisualMedia.VideoOnly
+                            ))
+                        }
+                        else -> {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                permissionLauncher.launch(Manifest.permission.READ_MEDIA_VIDEO)
+                            }
+                        }
+                    }
                 },
                 modifier = Modifier
                     .padding(top = 24.dp)
@@ -59,6 +90,7 @@ fun EmojiPage() {
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Preview(showBackground = true)
 @Composable
 fun EmojiPagePreview() {

--- a/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/EmojiPage.kt
@@ -27,11 +27,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.goliath.emojihub.LocalNavController
+import com.goliath.emojihub.NavigationDestination
 import com.goliath.emojihub.ui.theme.Color
+import com.goliath.emojihub.viewmodels.EmojiViewModel
 
 @Composable
 fun EmojiPage() {
     val context = LocalContext.current
+    val navController = LocalNavController.current
+
+    val viewModel = hiltViewModel<EmojiViewModel>()
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -40,7 +47,11 @@ fun EmojiPage() {
     val pickMediaLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.PickVisualMedia()
     ) { uri ->
-        uri.let { Log.d("PhotoPicker", "Selected URI: $uri") }
+        if (uri != null) {
+            Log.d("PhotoPicker", "Selected URI: $uri")
+            viewModel.videoUri = uri
+            navController.navigate(NavigationDestination.TransformVideo)
+        }
     }
 
     Box(

--- a/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
@@ -1,0 +1,79 @@
+package com.goliath.emojihub.views
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import com.goliath.emojihub.LocalNavController
+import com.goliath.emojihub.viewmodels.EmojiViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransformVideoPage(
+    viewModel: EmojiViewModel
+) {
+    val context = LocalContext.current
+    val navController = LocalNavController.current
+
+    val exoPlayer = remember {
+        ExoPlayer.Builder(context).build().apply {
+            setMediaItem(MediaItem.fromUri(viewModel.videoUri))
+            prepare()
+        }
+    }
+    val isPlaying = exoPlayer.isPlaying
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = {
+                        navController.popBackStack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = ""
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = {
+                            // TODO: implement
+                        }
+                    ) {
+                        Text(text = "변환", color = Color.Black)
+                    }
+                }
+            )
+        }
+    ) { it ->
+        AndroidView(
+            factory = {
+                PlayerView(it).apply {
+                    player = exoPlayer
+                }
+            },
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize()
+        )
+    }
+}

--- a/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import com.goliath.emojihub.LocalNavController
@@ -34,10 +35,10 @@ fun TransformVideoPage(
     val exoPlayer = remember {
         ExoPlayer.Builder(context).build().apply {
             setMediaItem(MediaItem.fromUri(viewModel.videoUri))
+            repeatMode = Player.REPEAT_MODE_ALL
             prepare()
         }
     }
-    val isPlaying = exoPlayer.isPlaying
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
### 수정사항
- 갤러리에 있는 미디어 중 비디오 파일을 선택하여 앱으로 불러올 수 있습니다
- 비디오 파일을 선택하면 즉시 `TransformVideoPage`로 이동하고, 영상 재생 버튼을 통해 업로드한 영상을 확인할 수 있습니다. 영상은 무한반복재생됩니다
- 뒤로가기 버튼을 누르면 이전 화면으로 돌아옵니다

### 참고사항
- `TransformVideoPage`로의 navigation을 위해 간단한 `NavigationDestination`의 구현이 포함되어 있습니다. 추후 프로젝트 전반에 걸쳐 적용하겠습니다
- 기획 중 `영상의 길이를 5초로 제한한다`는 아직 반영되지 않았습니다

### 에뮬레이터 영상
https://github.com/snuhcs-course/swpp-2023-project-team-2/assets/70614553/58775dc0-37a2-4f9d-93d7-3d77a5d50966

