### PR TITLE
feat: implement adding reaction to post

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     // jetpack compose
     implementation("androidx.activity:activity-compose:1.8.0")
     implementation("androidx.activity:activity-ktx:1.8.0")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.06.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")

--- a/android/app/src/main/java/com/goliath/emojihub/NavigationDestination.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/NavigationDestination.kt
@@ -3,4 +3,5 @@ package com.goliath.emojihub
 object NavigationDestination {
     const val TransformVideo = "transform_video"
     const val CreatePost = "create_post"
+    const val AddReactionBottomSheet = "add_reaction"
 }

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/PostUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/PostUseCase.kt
@@ -11,6 +11,7 @@ sealed interface PostUseCase {
     val postState: StateFlow<Post?>
     suspend fun fetchPostList()
     suspend fun uploadPost(content: String)
+    suspend fun addReaction()
 }
 class PostUseCaseImpl @Inject constructor(
     private val repository: PostRepository
@@ -23,5 +24,9 @@ class PostUseCaseImpl @Inject constructor(
     }
     override suspend fun uploadPost(content: String) {
         Log.d("Post", content)
+    }
+
+    override suspend fun addReaction() {
+        TODO("Not yet implemented")
     }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
@@ -14,4 +14,7 @@ class PostViewModel @Inject constructor(
     suspend fun uploadPost(content: String) {
         postUseCase.uploadPost(content)
     }
+    suspend fun addReaction() {
+        postUseCase.addReaction()
+    }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/views/AddReactionBottomSheet.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/AddReactionBottomSheet.kt
@@ -1,0 +1,107 @@
+package com.goliath.emojihub.views
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goliath.emojihub.LocalNavController
+import com.goliath.emojihub.models.createDummyEmoji
+import com.goliath.emojihub.views.components.EmojiCell
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun AddReactionBottomSheet(
+) {
+    val navController = LocalNavController.current
+    val sheetState = rememberModalBottomSheetState()
+    var isSheetShown by rememberSaveable { mutableStateOf(true) }
+    val emojiList = (1..10).map { createDummyEmoji() }
+
+    if(isSheetShown) {
+        ModalBottomSheet(
+            onDismissRequest = {
+                isSheetShown = false
+                navController.popBackStack()
+            },
+            sheetState = sheetState,) {
+            Column(Modifier.padding(horizontal = 16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(
+                        onClick = {
+                                  // TODO: fetch user's emojis and display
+                        },
+                        modifier = Modifier
+                            .padding(horizontal = 15.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = Color.White,
+                            contentColor = Color.Black
+                        )
+                    )
+                    {
+                        Text(
+                            text = "내가 만든 이모지",
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Button(
+                        onClick = {
+                                  // TODO: fetch user's saved emojis and display
+                        },
+                        modifier = Modifier
+                            .padding(horizontal = 15.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = Color.White,
+                            contentColor = Color.Black
+                        )
+                    ) {
+                        Text(
+                            text = "저장된 이모지",
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Column(Modifier.padding(horizontal = 16.dp)) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier.padding(top = 18.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                    items(emojiList.size) {index ->
+                        EmojiCell(emoji = emojiList[index])
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/android/app/src/main/java/com/goliath/emojihub/views/BottomNavigationBar.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/BottomNavigationBar.kt
@@ -45,6 +45,14 @@ fun BottomNavigationBar(
             val postViewModel = hiltViewModel<PostViewModel>(parentEntry)
             CreatePostPage(postViewModel)
         }
+
+        composable(NavigationDestination.AddReactionBottomSheet) {
+            val parentEntry = remember(it) {
+                navController.getBackStackEntry(PageItem.Feed.screenRoute)
+            }
+            val postViewModel = hiltViewModel<PostViewModel>(parentEntry)
+            AddReactionBottomSheet()
+        }
     }
 }
 

--- a/android/app/src/main/java/com/goliath/emojihub/views/components/PostCell.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/components/PostCell.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,15 +20,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.goliath.emojihub.LocalNavController
+import com.goliath.emojihub.NavigationDestination
 import com.goliath.emojihub.models.Post
 import com.goliath.emojihub.models.dummyPost
-import com.goliath.emojihub.ui.theme.Color
 import com.goliath.emojihub.ui.theme.Color.EmojiHubDetailLabel
 
 @Composable
 fun PostCell(
     post: Post
 ) {
+    val navController = LocalNavController.current
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -72,24 +75,14 @@ fun PostCell(
                     fontSize = 13.sp,
                     color = EmojiHubDetailLabel
                 )
-                Button(
-                    onClick = { /* TODO Handle Login Click*/ },
-                    modifier = Modifier
-                        .width(32.dp)
-                        .height(32.dp),
-                    shape = CircleShape,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color.Black,
-                        contentColor = Color.White
-                    ), content = {
-                        Text(
-                            text = "로그인",
-                            color = Color.White,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                )
+                IconButton(onClick = {
+                    navController.navigate(NavigationDestination.AddReactionBottomSheet)
+                }) {
+                    Icon(
+                        imageVector = Icons.Filled.AddReaction,
+                        contentDescription = ""
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Features added:
- Implemented bottomsheet for adding reaction to a post inside  `AddReactionBottomSheet.kt` component

Notes:
- For now, used dummy emojis to display in the bottom sheet. 
- BottomSheet is implemented as a page so, background becomes white as a result. (Should be fixed to be a part of `Feed Page `later)

![image](https://github.com/snuhcs-course/swpp-2023-project-team-2/assets/58340792/6299688c-09c5-4faa-8577-c2f679dcd384)
