### PR TITLE
Add showing dialog feature on api error

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/GlobalContext.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/GlobalContext.kt
@@ -1,0 +1,8 @@
+package com.goliath.emojihub
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.navigation.NavController
+
+val LocalNavController = compositionLocalOf<NavController> {
+    throw RuntimeException("")
+}

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
@@ -1,0 +1,53 @@
+package com.goliath.emojihub.data_sources
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed interface ApiErrorController {
+    val apiErrorState: StateFlow<CustomError?>
+    fun setErrorState(error: CustomError)
+    fun dismiss()
+}
+
+@Singleton
+class ApiErrorControllerImpl @Inject constructor(
+
+): ApiErrorController {
+
+    private val _apiErrorState = MutableStateFlow<CustomError?>(null)
+    override val apiErrorState: StateFlow<CustomError?>
+        get() = _apiErrorState
+
+    override fun setErrorState(error: CustomError) {
+        _apiErrorState.update { error }
+    }
+
+    override fun dismiss() {
+        _apiErrorState.update { null }
+    }
+}
+
+enum class CustomError(
+    statusCode: Int
+) {
+    BAD_REQUEST(400) {
+        override fun body(): String = "잘못된 요청입니다."
+    },
+    UNAUTHORIZED(401) {
+        override fun body(): String = "인증되지 않은 유저입니다."
+    },
+    FORBIDDEN(403) {
+        override fun body(): String = "잘못된 접근입니다."
+    },
+    NOT_FOUND(404) {
+        override fun body(): String = "요청하신 정보를 찾을 수 없습니다."
+    },
+    CONFLICT(409) {
+        override fun body(): String = "이미 있는 계정입니다."
+    };
+
+    abstract fun body(): String
+}

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/DataSourceModule.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/DataSourceModule.kt
@@ -4,6 +4,7 @@ import com.goliath.emojihub.data_sources.local.X3dDataSource
 import com.goliath.emojihub.data_sources.local.X3dDataSourceImpl
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
@@ -12,4 +13,7 @@ import dagger.hilt.components.SingletonComponent
 abstract class DataSourceModule {
     @Binds
     abstract fun bindsX3dDataSource(impl: X3dDataSourceImpl): X3dDataSource
+
+    @Binds
+    abstract fun bindsApiErrorController(impl: ApiErrorControllerImpl): ApiErrorController
 }

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/NetworkModule.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/NetworkModule.kt
@@ -1,6 +1,5 @@
 package com.goliath.emojihub.data_sources
 
-import android.util.Log
 import com.goliath.emojihub.EmojiHubApplication
 import com.goliath.emojihub.data_sources.api.EmojiApi
 import com.goliath.emojihub.data_sources.api.PostApi

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/SharedLocalStorage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/SharedLocalStorage.kt
@@ -3,8 +3,13 @@ package com.goliath.emojihub.data_sources
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
 
-class SharedLocalStorage(context: Context) {
+@Singleton
+class SharedLocalStorage(
+    @ApplicationContext private val context: Context
+) {
     private val preferences: SharedPreferences =
         context.getSharedPreferences("EMOJI_HUB", MODE_PRIVATE)
 

--- a/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
@@ -37,8 +37,6 @@ class UserRepositoryImpl @Inject constructor(
             val accessToken = result.body()?.accessToken
             Log.d("Login Success", accessToken.toString())
             return accessToken
-        } else {
-            Log.d("Login Failure", result.raw().toString())
         }
         return null
     }

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
@@ -2,6 +2,8 @@ package com.goliath.emojihub.usecases
 
 import android.util.Log
 import com.goliath.emojihub.EmojiHubApplication
+import com.goliath.emojihub.data_sources.ApiErrorController
+import com.goliath.emojihub.data_sources.CustomError
 import com.goliath.emojihub.models.LoginUserDto
 import com.goliath.emojihub.models.RegisterUserDto
 import com.goliath.emojihub.models.User
@@ -26,7 +28,8 @@ sealed interface UserUseCase {
 
 @Singleton
 class UserUseCaseImpl @Inject constructor(
-    private val repository: UserRepository
+    private val repository: UserRepository,
+    private val errorController: ApiErrorController
 ): UserUseCase {
 
     private val _userState = MutableStateFlow<User?>(null)
@@ -55,6 +58,8 @@ class UserUseCaseImpl @Inject constructor(
             Log.d("Login Success: Access token", accessToken)
             _userState.update { User(UserDto(accessToken, name)) }
             EmojiHubApplication.preferences.accessToken = accessToken
+        } else {
+            errorController.setErrorState(CustomError.BAD_REQUEST)
         }
     }
 

--- a/android/app/src/main/java/com/goliath/emojihub/views/CreatePostPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/CreatePostPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.goliath.emojihub.LocalNavController
 import com.goliath.emojihub.ui.theme.Color
 import com.goliath.emojihub.viewmodels.PostViewModel
+import com.goliath.emojihub.views.components.CustomDialog
 import com.goliath.emojihub.views.components.TopNavigationBar
 import kotlinx.coroutines.launch
 
@@ -55,7 +56,9 @@ fun CreatePostPage(
             }
 
             TextField(
-                modifier = Modifier.fillMaxSize().padding(bottom = 16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 16.dp),
                 value = content,
                 onValueChange = { content = it },
                 placeholder = { Text("오늘 무슨 일이 있었나요?") },
@@ -70,16 +73,10 @@ fun CreatePostPage(
         }
 
         if (showSuccessDialog) {
-            AlertDialog(
-                onDismissRequest = {},
-                title = { Text(text = "완료", fontWeight = FontWeight.Bold) },
-                text = { Text(text = "포스트 업로드가 완료되었습니다.") },
-                shape = RoundedCornerShape(20.dp),
-                confirmButton = {
-                    TextButton(onClick = { navController.popBackStack() }) {
-                        Text(text = "확인")
-                    }
-                }
+            CustomDialog(
+                title = "완료",
+                body = "포스트 업로드가 완료되었습니다.",
+                confirm = { navController.popBackStack() }
             )
         }
     }

--- a/android/app/src/main/java/com/goliath/emojihub/views/ProfilePage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/ProfilePage.kt
@@ -8,9 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.TextButton
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,12 +24,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.goliath.emojihub.ui.theme.Color
-import com.goliath.emojihub.ui.theme.Color.Black
 import com.goliath.emojihub.ui.theme.Color.EmojiHubDetailLabel
-import com.goliath.emojihub.ui.theme.Color.EmojiHubLabel
-import com.goliath.emojihub.ui.theme.Color.EmojiHubRed
 import com.goliath.emojihub.ui.theme.Color.White
 import com.goliath.emojihub.viewmodels.UserViewModel
+import com.goliath.emojihub.views.components.CustomDialog
 import com.goliath.emojihub.views.components.EmptyProfile
 import com.goliath.emojihub.views.components.ProfileMenuCell
 import com.goliath.emojihub.views.components.TopNavigationBar
@@ -102,40 +97,24 @@ fun ProfilePage(
                 }
 
                 if (showLogoutDialog) {
-                    AlertDialog(
+                    CustomDialog(
+                        title = "로그아웃",
+                        body = "로그아웃하시겠습니까?",
                         onDismissRequest = { showLogoutDialog = false },
-                        title = { Text(text = "로그아웃", fontWeight = FontWeight.Bold) },
-                        text = { Text(text = "로그아웃하시겠습니까?") },
-                        shape = RoundedCornerShape(20.dp),
-                        dismissButton = {
-                            TextButton(onClick = { showLogoutDialog = false }) {
-                                Text(text = "취소", color = EmojiHubLabel)
-                            }
-                        },
-                        confirmButton = {
-                            TextButton(onClick = { userViewModel.logout() }) {
-                                Text(text = "확인", color = Black)
-                            }
-                        }
+                        dismiss = { showLogoutDialog = false },
+                        confirm = { userViewModel.logout() }
                     )
                 }
 
                 if (showSignOutDialog) {
-                    AlertDialog(
+                    CustomDialog(
+                        title = "회원 탈퇴",
+                        body = "계정을 삭제하시겠습니까?",
+                        confirmText = "삭제",
+                        isDestructive = true,
                         onDismissRequest = { showSignOutDialog = false },
-                        title = { Text(text = "회원 탈퇴", fontWeight = FontWeight.Bold) },
-                        text = { Text(text = "계정을 삭제하시겠습니까?") },
-                        shape = RoundedCornerShape(20.dp),
-                        dismissButton = {
-                            TextButton(onClick = { showSignOutDialog = false }) {
-                                Text(text = "취소", color = EmojiHubLabel)
-                            }
-                        },
-                        confirmButton = {
-                            TextButton(onClick = { userViewModel.signOut() }) {
-                                Text(text = "삭제", color = EmojiHubRed)
-                            }
-                        }
+                        dismiss = { showSignOutDialog = false },
+                        confirm = { userViewModel.signOut() }
                     )
                 }
             } else {

--- a/android/app/src/main/java/com/goliath/emojihub/views/ProfilePage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/ProfilePage.kt
@@ -100,6 +100,7 @@ fun ProfilePage(
                     CustomDialog(
                         title = "로그아웃",
                         body = "로그아웃하시겠습니까?",
+                        needsCancelButton = true,
                         onDismissRequest = { showLogoutDialog = false },
                         dismiss = { showLogoutDialog = false },
                         confirm = { userViewModel.logout() }
@@ -112,6 +113,7 @@ fun ProfilePage(
                         body = "계정을 삭제하시겠습니까?",
                         confirmText = "삭제",
                         isDestructive = true,
+                        needsCancelButton = true,
                         onDismissRequest = { showSignOutDialog = false },
                         dismiss = { showSignOutDialog = false },
                         confirm = { userViewModel.signOut() }

--- a/android/app/src/main/java/com/goliath/emojihub/views/components/CustomDialog.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/components/CustomDialog.kt
@@ -15,16 +15,22 @@ fun CustomDialog(
     body: String = "",
     confirmText: String = "확인",
     isDestructive: Boolean = false,
+    needsCancelButton: Boolean = false,
     onDismissRequest: () -> Unit = {},
     confirm: () -> Unit = {},
     dismiss: () -> Unit = {}
 ) {
-    if (dismiss == {}) {
+    if (needsCancelButton) {
         AlertDialog(
             onDismissRequest = { onDismissRequest() },
             title = { Text(title, fontWeight = FontWeight.Bold) },
             text = { Text(body) },
             shape = RoundedCornerShape(20.dp),
+            dismissButton = {
+                TextButton(onClick = { dismiss() }) {
+                    Text(text = "취소", color = Color.EmojiHubLabel)
+                }
+            },
             confirmButton = {
                 TextButton(onClick = { confirm() }) {
                     Text(text = confirmText, color =
@@ -40,11 +46,6 @@ fun CustomDialog(
             title = { Text(title, fontWeight = FontWeight.Bold) },
             text = { Text(body) },
             shape = RoundedCornerShape(20.dp),
-            dismissButton = {
-                TextButton(onClick = { dismiss() }) {
-                    Text(text = "취소", color = Color.EmojiHubLabel)
-                }
-            },
             confirmButton = {
                 TextButton(onClick = { confirm() }) {
                     Text(text = confirmText, color =

--- a/android/app/src/main/java/com/goliath/emojihub/views/components/CustomDialog.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/components/CustomDialog.kt
@@ -1,0 +1,58 @@
+package com.goliath.emojihub.views.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.goliath.emojihub.ui.theme.Color
+
+@Composable
+fun CustomDialog(
+    title: String,
+    body: String = "",
+    confirmText: String = "확인",
+    isDestructive: Boolean = false,
+    onDismissRequest: () -> Unit = {},
+    confirm: () -> Unit = {},
+    dismiss: () -> Unit = {}
+) {
+    if (dismiss == {}) {
+        AlertDialog(
+            onDismissRequest = { onDismissRequest() },
+            title = { Text(title, fontWeight = FontWeight.Bold) },
+            text = { Text(body) },
+            shape = RoundedCornerShape(20.dp),
+            confirmButton = {
+                TextButton(onClick = { confirm() }) {
+                    Text(text = confirmText, color =
+                    if (isDestructive) Color.EmojiHubRed
+                    else Color.Black
+                    )
+                }
+            }
+        )
+    } else {
+        AlertDialog(
+            onDismissRequest = { onDismissRequest() },
+            title = { Text(title, fontWeight = FontWeight.Bold) },
+            text = { Text(body) },
+            shape = RoundedCornerShape(20.dp),
+            dismissButton = {
+                TextButton(onClick = { dismiss() }) {
+                    Text(text = "취소", color = Color.EmojiHubLabel)
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { confirm() }) {
+                    Text(text = confirmText, color =
+                    if (isDestructive) Color.EmojiHubRed
+                    else Color.Black
+                    )
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
### 수정사항
- 안드로이드 프로젝트 내부에서 이용할 공통 컴포넌트 `CustomDialog`를 생성했습니다
- API 호출 시 에러가 발생하는 경우에 Dialog를 띄울 수 있도록 셋업을 하고, 안드로이드 프로젝트 내부에서 이용할 `CustomError`를 정의하였습니다
- 각종 에러를 처리할 `ApiErrorController`가 추가되었습니다. 일단은 `data_source` 디렉토리에 생성하긴 했는데, 더 괜찮은 위치가 있다면 이동해야할 것 같아요

### 테스트 방법
- 로그인 화면에서 `username7`과 틀린 비밀번호를 입력할 경우 `잘못된 요청입니다.`라는 dialog가 뜹니다

### 참고사진
![스크린샷 2023-11-06 오전 12 34 21](https://github.com/snuhcs-course/swpp-2023-project-team-2/assets/70614553/20ffd27a-575d-4023-8e33-d2672c556961)
