### PR TITLE
Add error dialog for all cases

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
@@ -8,7 +8,7 @@ import javax.inject.Singleton
 
 sealed interface ApiErrorController {
     val apiErrorState: StateFlow<CustomError?>
-    fun setErrorState(error: CustomError)
+    fun setErrorState(errorCode: Int)
     fun dismiss()
 }
 
@@ -21,8 +21,17 @@ class ApiErrorControllerImpl @Inject constructor(
     override val apiErrorState: StateFlow<CustomError?>
         get() = _apiErrorState
 
-    override fun setErrorState(error: CustomError) {
-        _apiErrorState.update { error }
+    override fun setErrorState(errorCode: Int) {
+        _apiErrorState.update {
+            when (errorCode) {
+                CustomError.BAD_REQUEST.ordinal -> CustomError.BAD_REQUEST
+                CustomError.UNAUTHORIZED.ordinal -> CustomError.UNAUTHORIZED
+                CustomError.FORBIDDEN.ordinal -> CustomError.FORBIDDEN
+                CustomError.NOT_FOUND.ordinal -> CustomError.NOT_FOUND
+                CustomError.CONFLICT.ordinal -> CustomError.CONFLICT
+                else -> CustomError.BAD_REQUEST
+            }
+        }
     }
 
     override fun dismiss() {

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/ApiErrorController.kt
@@ -23,14 +23,7 @@ class ApiErrorControllerImpl @Inject constructor(
 
     override fun setErrorState(errorCode: Int) {
         _apiErrorState.update {
-            when (errorCode) {
-                CustomError.BAD_REQUEST.ordinal -> CustomError.BAD_REQUEST
-                CustomError.UNAUTHORIZED.ordinal -> CustomError.UNAUTHORIZED
-                CustomError.FORBIDDEN.ordinal -> CustomError.FORBIDDEN
-                CustomError.NOT_FOUND.ordinal -> CustomError.NOT_FOUND
-                CustomError.CONFLICT.ordinal -> CustomError.CONFLICT
-                else -> CustomError.BAD_REQUEST
-            }
+            CustomError.getBy(errorCode)
         }
     }
 
@@ -40,7 +33,7 @@ class ApiErrorControllerImpl @Inject constructor(
 }
 
 enum class CustomError(
-    statusCode: Int
+    val statusCode: Int
 ) {
     BAD_REQUEST(400) {
         override fun body(): String = "잘못된 요청입니다."
@@ -57,6 +50,10 @@ enum class CustomError(
     CONFLICT(409) {
         override fun body(): String = "이미 있는 계정입니다."
     };
+
+    companion object {
+        fun getBy(statusCode: Int) = values().firstOrNull { it.statusCode == statusCode }
+    }
 
     abstract fun body(): String
 }

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/NetworkModule.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/NetworkModule.kt
@@ -19,6 +19,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.lang.reflect.Type
 import javax.inject.Inject
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -44,14 +45,17 @@ object NetworkModule {
             .build()
 
     @Provides
+    @Singleton
     fun providesUserRestApi(retrofit: Retrofit): UserApi =
         retrofit.create(UserApi::class.java)
 
     @Provides
+    @Singleton
     fun providesEmojiRestApi(retrofit: Retrofit): EmojiApi =
         retrofit.create(EmojiApi::class.java)
 
     @Provides
+    @Singleton
     fun providesPostRestApi(retrofit: Retrofit): PostApi =
         retrofit.create(PostApi::class.java)
 

--- a/android/app/src/main/java/com/goliath/emojihub/repositories/remote/PostRepository.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/repositories/remote/PostRepository.kt
@@ -4,12 +4,13 @@ import android.util.Log
 import com.goliath.emojihub.data_sources.api.PostApi
 import com.goliath.emojihub.models.PostDto
 import com.goliath.emojihub.models.UploadPostDto
+import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
 interface PostRepository {
     suspend fun fetchPostList(numLimit: Int): List<PostDto>
-    suspend fun uploadPost(content: String): Boolean
+    suspend fun uploadPost(dto: UploadPostDto): Response<Unit>
     suspend fun getPostWithId(id: String): PostDto?
     suspend fun editPost(id: String, content: String)
     suspend fun deletePost(id: String)
@@ -23,9 +24,8 @@ class PostRepositoryImpl @Inject constructor(
         return postApi.fetchPostList(numLimit).body() ?: listOf()
     }
 
-    override suspend fun uploadPost(content: String): Boolean {
-        val dto = UploadPostDto(content)
-        return postApi.uploadPost(dto).isSuccessful
+    override suspend fun uploadPost(dto: UploadPostDto): Response<Unit> {
+        return postApi.uploadPost(dto)
     }
 
     override suspend fun getPostWithId(id: String): PostDto? {

--- a/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
@@ -1,10 +1,11 @@
 package com.goliath.emojihub.repositories.remote
 
-import android.util.Log
 import com.goliath.emojihub.data_sources.api.UserApi
 import com.goliath.emojihub.models.LoginUserDto
 import com.goliath.emojihub.models.RegisterUserDto
 import com.goliath.emojihub.models.UserDtoList
+import com.goliath.emojihub.models.responses.LoginResponseDto
+import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,7 +13,7 @@ interface UserRepository {
     suspend fun fetchUserList(): Array<UserDtoList>
     fun fetchUser(name: String)
     suspend fun registerUser(dto: RegisterUserDto)
-    suspend fun login(dto: LoginUserDto): String?
+    suspend fun login(dto: LoginUserDto): Response<LoginResponseDto>?
 }
 
 @Singleton
@@ -31,13 +32,7 @@ class UserRepositoryImpl @Inject constructor(
         userApi.registerUser(dto)
     }
 
-    override suspend fun login(dto: LoginUserDto): String? {
-        val result = userApi.login(dto)
-        if (result.isSuccessful) {
-            val accessToken = result.body()?.accessToken
-            Log.d("Login Success", accessToken.toString())
-            return accessToken
-        }
-        return null
+    override suspend fun login(dto: LoginUserDto): Response<LoginResponseDto>? {
+        return userApi.login(dto)
     }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/repositories/remote/UserRepository.kt
@@ -13,7 +13,7 @@ interface UserRepository {
     suspend fun fetchUserList(): Array<UserDtoList>
     fun fetchUser(name: String)
     suspend fun registerUser(dto: RegisterUserDto)
-    suspend fun login(dto: LoginUserDto): Response<LoginResponseDto>?
+    suspend fun login(dto: LoginUserDto): Response<LoginResponseDto>
 }
 
 @Singleton
@@ -32,7 +32,7 @@ class UserRepositoryImpl @Inject constructor(
         userApi.registerUser(dto)
     }
 
-    override suspend fun login(dto: LoginUserDto): Response<LoginResponseDto>? {
+    override suspend fun login(dto: LoginUserDto): Response<LoginResponseDto> {
         return userApi.login(dto)
     }
 }

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
@@ -53,13 +53,15 @@ class UserUseCaseImpl @Inject constructor(
 
     override suspend fun login(name: String, password: String) {
         val dto = LoginUserDto(name, password)
-        val accessToken = repository.login(dto)
-        if (!accessToken.isNullOrEmpty()) {
-            Log.d("Login Success: Access token", accessToken)
-            _userState.update { User(UserDto(accessToken, name)) }
-            EmojiHubApplication.preferences.accessToken = accessToken
-        } else {
-            errorController.setErrorState(CustomError.BAD_REQUEST)
+        val response = repository.login(dto)
+        response?.let {
+            if (it.isSuccessful) {
+                val accessToken = it.body()?.accessToken
+                _userState.update { User(UserDto(accessToken ?: "", name)) }
+                EmojiHubApplication.preferences.accessToken = accessToken
+            } else {
+                errorController.setErrorState(it.code())
+            }
         }
     }
 

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
@@ -1,9 +1,7 @@
 package com.goliath.emojihub.usecases
 
-import android.util.Log
 import com.goliath.emojihub.EmojiHubApplication
 import com.goliath.emojihub.data_sources.ApiErrorController
-import com.goliath.emojihub.data_sources.CustomError
 import com.goliath.emojihub.models.LoginUserDto
 import com.goliath.emojihub.models.RegisterUserDto
 import com.goliath.emojihub.models.User

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
@@ -52,7 +52,7 @@ class UserUseCaseImpl @Inject constructor(
     override suspend fun login(name: String, password: String) {
         val dto = LoginUserDto(name, password)
         val response = repository.login(dto)
-        response?.let {
+        response.let {
             if (it.isSuccessful) {
                 val accessToken = it.body()?.accessToken
                 _userState.update { User(UserDto(accessToken ?: "", name)) }

--- a/android/app/src/main/java/com/goliath/emojihub/views/CreatePostPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/CreatePostPage.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.TextField
@@ -17,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.goliath.emojihub.LocalNavController


### PR DESCRIPTION
### 수정사항
- Api Error의 StatusCode에 따라 서로 다른 문구의 error dialog를 띄웁니다
- `Repository`에서는 `Response<T>`를 반환, `UseCase`에서는 `Response<T>`의 `isSuccessful` 여부에 따라 `T`를 이용한 성공 응답을 반환하거나 `statusCode`를 `ApiErrorController`에 보내 앱 전역에 error dialog를 띄웁니다

### 테스트 방법
- 아이디에 아무 값이나 입력 후 로그인 시도: `404`
- 아이디에 `username7`, 비밀번호에 `password7`이 아닌 값을 입력 후 로그인 시도: `401`