### PR TITLE
Add post pagination feature for `FeedPage`

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -86,6 +86,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material:1.5.3")
+    implementation("androidx.paging:paging-compose:3.2.1")
+    implementation("androidx.paging:paging-runtime-ktx:3.2.1")
 
     // jetpack compose extended icons
     implementation("androidx.compose.material:material-icons-extended:1.5.4")

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/PostPagingSource.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/PostPagingSource.kt
@@ -1,0 +1,33 @@
+package com.goliath.emojihub.data_sources
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.goliath.emojihub.data_sources.api.PostApi
+import com.goliath.emojihub.models.PostDto
+import javax.inject.Inject
+
+class PostPagingSource @Inject constructor(
+    private val api: PostApi
+): PagingSource<Int, PostDto>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PostDto> {
+        val cursor = params.key ?: 1
+        return try {
+            val response = api.fetchPostList(cursor).body()
+            val data = response ?: listOf()
+            LoadResult.Page(
+                data = data,
+                prevKey = if (cursor == 1) null else cursor - 1,
+                nextKey = if (data.isEmpty()) null else cursor + 1
+            )
+        } catch (exception: Exception) {
+            LoadResult.Error(exception)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, PostDto>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/android/app/src/main/java/com/goliath/emojihub/data_sources/api/PostApi.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/data_sources/api/PostApi.kt
@@ -14,7 +14,7 @@ import retrofit2.http.Query
 interface PostApi {
     @GET("post")
     suspend fun fetchPostList(
-        @Query("numLimit") numLimit: Int
+        @Query("index") index: Int
     ): Response<List<PostDto>>
 
     @GET("post")

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/PostUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/PostUseCase.kt
@@ -7,10 +7,14 @@ import com.goliath.emojihub.models.Post
 import com.goliath.emojihub.models.UploadPostDto
 import com.goliath.emojihub.repositories.remote.PostRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 sealed interface PostUseCase {
+    val postList: StateFlow<PagingData<Post>>
+    suspend fun updatePostList(data: PagingData<Post>)
     suspend fun fetchPostList(): Flow<PagingData<Post>>
     suspend fun uploadPost(content: String): Boolean
     suspend fun getPostWithId(id: String)
@@ -21,6 +25,14 @@ class PostUseCaseImpl @Inject constructor(
     private val repository: PostRepository,
     private val errorController: ApiErrorController
 ): PostUseCase {
+
+    private val _postList = MutableStateFlow<PagingData<Post>>(PagingData.empty())
+    override val postList: StateFlow<PagingData<Post>>
+        get() = _postList
+
+    override suspend fun updatePostList(data: PagingData<Post>) {
+        _postList.emit(data)
+    }
 
     override suspend fun fetchPostList(): Flow<PagingData<Post>> {
         return repository.fetchPostList().map { it.map { dto -> Post(dto) } }

--- a/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/usecases/UserUseCase.kt
@@ -1,6 +1,5 @@
 package com.goliath.emojihub.usecases
 
-import androidx.compose.ui.window.Dialog
 import com.goliath.emojihub.EmojiHubApplication
 import com.goliath.emojihub.data_sources.ApiErrorController
 import com.goliath.emojihub.models.LoginUserDto

--- a/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
@@ -2,13 +2,9 @@ package com.goliath.emojihub.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import com.goliath.emojihub.models.Post
 import com.goliath.emojihub.usecases.PostUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,16 +12,15 @@ import javax.inject.Inject
 class PostViewModel @Inject constructor(
     private val postUseCase: PostUseCase
 ): ViewModel() {
-    private val _postList = MutableStateFlow<PagingData<Post>>(PagingData.empty())
-    val postList: StateFlow<PagingData<Post>>
-        get() = _postList
+
+    val postList = postUseCase.postList
 
     init {
         viewModelScope.launch {
             postUseCase.fetchPostList()
                 .cachedIn(viewModelScope)
                 .collect {
-                    _postList.emit(it)
+                    postUseCase.updatePostList(it)
                 }
         }
     }

--- a/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
@@ -15,7 +15,7 @@ class PostViewModel @Inject constructor(
 
     val postList = postUseCase.postList
 
-    init {
+    suspend fun fetchPostList() {
         viewModelScope.launch {
             postUseCase.fetchPostList()
                 .cachedIn(viewModelScope)

--- a/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/viewmodels/PostViewModel.kt
@@ -1,15 +1,14 @@
 package com.goliath.emojihub.viewmodels
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.goliath.emojihub.models.Post
 import com.goliath.emojihub.usecases.PostUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -17,21 +16,22 @@ import javax.inject.Inject
 class PostViewModel @Inject constructor(
     private val postUseCase: PostUseCase
 ): ViewModel() {
-    private val _postList = MutableStateFlow<List<Post>>(emptyList())
-    val postList: StateFlow<List<Post>> = _postList.asStateFlow()
+    private val _postList = MutableStateFlow<PagingData<Post>>(PagingData.empty())
+    val postList: StateFlow<PagingData<Post>>
+        get() = _postList
+
+    init {
+        viewModelScope.launch {
+            postUseCase.fetchPostList()
+                .cachedIn(viewModelScope)
+                .collect {
+                    _postList.emit(it)
+                }
+        }
+    }
 
     suspend fun uploadPost(content: String): Boolean {
         return postUseCase.uploadPost(content)
-    }
-
-    fun fetchPostList(numLimit: Int) {
-        Log.d("VM", "HERE")
-        viewModelScope.launch {
-            postUseCase.fetchPostList(numLimit)
-
-            val posts = postUseCase.postListState.value.map { dto -> Post(dto) }
-            _postList.emit(posts)
-        }
     }
 
     suspend fun getPostWithId(id: String) {

--- a/android/app/src/main/java/com/goliath/emojihub/views/FeedPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/FeedPage.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -51,6 +52,10 @@ fun FeedPage() {
 
     val emojiList = (1..10).map { createDummyEmoji() }
     val postList = postViewModel.postList.collectAsLazyPagingItems()
+
+    LaunchedEffect(Unit) {
+        postViewModel.fetchPostList()
+    }
 
     Column (
         Modifier.background(Color.White)

--- a/android/app/src/main/java/com/goliath/emojihub/views/FeedPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/FeedPage.kt
@@ -1,4 +1,5 @@
 package com.goliath.emojihub.views
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,7 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
@@ -25,13 +25,12 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.goliath.emojihub.LocalNavController
 import com.goliath.emojihub.NavigationDestination
 import com.goliath.emojihub.models.createDummyEmoji
@@ -49,14 +48,9 @@ fun FeedPage() {
     val navController = LocalNavController.current
     val emojiViewModel = hiltViewModel<EmojiViewModel>()
     val postViewModel = hiltViewModel<PostViewModel>()
+
     val emojiList = (1..10).map { createDummyEmoji() }
-
-    LaunchedEffect(Unit)
-    {
-        postViewModel.fetchPostList(10)
-    }
-
-    val postList = postViewModel.postList.collectAsState().value
+    val postList = postViewModel.postList.collectAsLazyPagingItems()
 
     Column (
         Modifier.background(Color.White)
@@ -81,9 +75,11 @@ fun FeedPage() {
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(horizontal = 16.dp)
             ) {
-                items(postList, key = {it.id}) { post ->
-                    PostCell(post = post)
-                    Divider(color = EmojiHubDividerColor, thickness = 0.5.dp)
+                items(postList.itemCount) { index ->
+                    postList[index]?.let {
+                        PostCell(post = it)
+                        Divider(color = EmojiHubDividerColor, thickness = 0.5.dp)
+                    }
                 }
             }
         }


### PR DESCRIPTION
### 수정사항
- `FeedPage`에서 `Post` 목록을 불러올 때 pagination을 지원합니다
- `viewModelScope`의 사용이 필요하다는 점과 `MutableStateFlow` 타입의 값들을 UseCase에서 관리한다는 점 모두를 충족하려다보니 아래의 흐름을 가지게 되었는데 고민이네요. PostList만 예외적으로 ViewModel에서 관리하는 것과 UseCase에서 관리하는 것 무엇이 좋을지 의견 있다면 부탁드립니다.
```
ViewModel -> UseCase -> Repository -> DataSource (Fetching) 
-> Repository -> UseCase -> ViewModel (Retrieving data)
 -> UseCase -> ViewModel -> View (Draw UI)
```