### PR TITLE
fix: video playback issue when navigating away from the view

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/views/components/PlayEmojiView.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/components/PlayEmojiView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileDownloadOff
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,6 +59,13 @@ fun PlayEmojiView(
             setMediaItem(MediaItem.fromUri(currentEmoji.videoLink))
             repeatMode = Player.REPEAT_MODE_ALL
             prepare()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            exoPlayer.stop()
+            exoPlayer.release()
         }
     }
 


### PR DESCRIPTION
## 수정사항
* 이모지의 영상을 재생한 후 해당 view를 나가도 백그라운드에서 계속 영상이 재생되는 문제를 해결하였습니다.