### PR TITLE
Fix BottomNavigation state being remained when user switched

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/views/MainPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/MainPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -17,6 +18,10 @@ import com.goliath.emojihub.R
 fun MainPage() {
     val bottomNavigationController = LocalBottomNavigationController.current
     val currentRoute = bottomNavigationController.currentDestination.value
+
+    LaunchedEffect(Unit) {
+        bottomNavigationController.updateDestination(PageItem.Feed)
+    }
 
     Column(Modifier.fillMaxSize()) {
         Box(Modifier.weight(1f)) {


### PR DESCRIPTION
### 수정사항
- ProfileTab에 최초 진입 후 로그아웃을 한 뒤, 다시 로그인하거나 비회원모드로 접속 시 `FeedPage`가 아닌 `ProfilePage`로 이동하는 문제를 수정하였습니다