### PR TITLE
fix: fix getReactionOfPost API to get emoji of each reaction

### DIFF
--- a/springboot/src/main/kotlin/com/goliath/emojihub/springboot/domain/reaction/controller/ReactionController.kt
+++ b/springboot/src/main/kotlin/com/goliath/emojihub/springboot/domain/reaction/controller/ReactionController.kt
@@ -1,6 +1,6 @@
 package com.goliath.emojihub.springboot.domain.reaction.controller
 
-import com.goliath.emojihub.springboot.domain.reaction.dto.ReactionDto
+import com.goliath.emojihub.springboot.domain.reaction.dto.ReactionWithEmoji
 import com.goliath.emojihub.springboot.domain.reaction.service.ReactionService
 import com.goliath.emojihub.springboot.domain.user.model.CurrentUser
 import org.springframework.http.HttpStatus
@@ -17,7 +17,7 @@ class ReactionController(private val reactionService: ReactionService) {
         @RequestParam(value = "emojiUnicode", defaultValue = "") emojiUnicode: String,
         @RequestParam(value = "index", defaultValue = 1.toString()) index: Int,
         @RequestParam(value = "count", defaultValue = 10.toString()) count: Int
-    ): ResponseEntity<List<ReactionDto>> {
+    ): ResponseEntity<List<ReactionWithEmoji>> {
         return ResponseEntity.ok(reactionService.getReactionsOfPost(postId, emojiUnicode, index, count))
     }
 

--- a/springboot/src/main/kotlin/com/goliath/emojihub/springboot/domain/reaction/dto/ReactionWithEmoji.kt
+++ b/springboot/src/main/kotlin/com/goliath/emojihub/springboot/domain/reaction/dto/ReactionWithEmoji.kt
@@ -1,0 +1,22 @@
+package com.goliath.emojihub.springboot.domain.reaction.dto
+
+import com.goliath.emojihub.springboot.domain.emoji.dto.EmojiDto
+
+data class ReactionWithEmoji(
+    var id: String = "",
+    var created_by: String = "",
+    var post_id: String = "",
+    var emoji_id: String = "",
+    var created_at: String = "",
+    // reactionDto 안에 emojiDto 만 추가
+    var emojiDto: EmojiDto? = null
+) {
+    constructor(reactionDto: ReactionDto, emojiDto: EmojiDto?): this() {
+        id = reactionDto.id
+        created_by = reactionDto.created_by
+        post_id = reactionDto.post_id
+        emoji_id = reactionDto.emoji_id
+        created_at = reactionDto.created_at
+        this.emojiDto = emojiDto
+    }
+}

--- a/springboot/src/test/kotlin/com/goliath/emojihub/springboot/domain/reaction/service/ReactionServiceTest.kt
+++ b/springboot/src/test/kotlin/com/goliath/emojihub/springboot/domain/reaction/service/ReactionServiceTest.kt
@@ -5,6 +5,7 @@ import com.goliath.emojihub.springboot.domain.emoji.dao.EmojiDao
 import com.goliath.emojihub.springboot.domain.post.dao.PostDao
 import com.goliath.emojihub.springboot.domain.reaction.dao.ReactionDao
 import com.goliath.emojihub.springboot.domain.reaction.dto.ReactionDto
+import com.goliath.emojihub.springboot.domain.reaction.dto.ReactionWithEmoji
 import com.goliath.emojihub.springboot.domain.user.dao.UserDao
 import com.goliath.emojihub.springboot.global.exception.CustomHttp400
 import com.goliath.emojihub.springboot.global.exception.CustomHttp403
@@ -90,9 +91,30 @@ internal class ReactionServiceTest {
                 Integer.min(index * count, reactionsSpecific.size)
             )
         }
+        val reactionWithEmojiAllList = mutableListOf<ReactionWithEmoji>()
+        val reactionWithEmojiSpecificList = mutableListOf<ReactionWithEmoji>()
+        for (reaction in reactionsAll) {
+            for (emoji in testDto.emojiList) {
+                if (emoji.id != reaction.emoji_id) continue
+                reactionWithEmojiAllList.add(
+                    ReactionWithEmoji(reaction, emoji)
+                )
+            }
+        }
+        for (reaction in reactionsSpecific) {
+            for (emoji in testDto.emojiList) {
+                if (emoji.id != reaction.emoji_id) continue
+                reactionWithEmojiSpecificList.add(
+                    ReactionWithEmoji(reaction, emoji)
+                )
+            }
+        }
         Mockito.`when`(reactionDao.getReactionsWithField(postId, POST_ID.string)).thenReturn(reactionsAll)
         for (reaction in reactionsSpecific) {
             Mockito.`when`(reactionDao.getReaction(reaction.id)).thenReturn(reaction)
+        }
+        for (emoji in testDto.emojiList) {
+            Mockito.`when`(emojiDao.getEmoji(emoji.id)).thenReturn(emoji)
         }
 
         // when
@@ -110,8 +132,8 @@ internal class ReactionServiceTest {
 
         // then
         assertAll(
-            { assertEquals(result1, reactionsAll) },
-            { assertEquals(result2, reactionsSpecific) },
+            { assertEquals(result1, reactionWithEmojiAllList) },
+            { assertEquals(result2, reactionWithEmojiSpecificList) },
             { assertEquals(assertThrows1.message, INDEX_OUT_OF_BOUND.getMessage()) },
             { assertEquals(assertThrows2.message, COUNT_OUT_OF_BOUND.getMessage()) },
             { assertEquals(assertThrows3.message, POST_NOT_FOUND.getMessage()) },


### PR DESCRIPTION
## 수정사항

* 특정 post의 reaction들을 불러올 때 reaction의 emoji들을 함께 보내도록 수정하였습니다.

보내는 List<ReactionWithEmoji>의 ReactionWithEmoji는 다음과 같습니다.
![image](https://github.com/snuhcs-course/swpp-2023-project-team-2/assets/110642616/3d6c7aa4-4e2c-4ef8-859b-9a18e3bcef60)

다음과 같이 보내집니다.
![image](https://github.com/snuhcs-course/swpp-2023-project-team-2/assets/110642616/83b90b68-ffe4-4c47-bffa-72e58e4d8eb7)
