### PR TITLE
Fix `BottomNavigation` always being set as `Feed`

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/views/LoginPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/LoginPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +36,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.goliath.emojihub.LocalBottomNavigationController
 import com.goliath.emojihub.LocalNavController
 import com.goliath.emojihub.NavigationDestination
 import com.goliath.emojihub.R
@@ -56,15 +58,21 @@ fun LoginPage() {
 
     val userViewModel = hiltViewModel<UserViewModel>()
     val coroutineScope = rememberCoroutineScope()
+
     val navController = LocalNavController.current
+    val bottomNavigationController = LocalBottomNavigationController.current
+
+    LaunchedEffect(Unit) {
+        bottomNavigationController.updateDestination(PageItem.Feed)
+    }
 
     Box(modifier = Modifier
-            .background(Color.White)
-            .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .clickable(interactionSource = interactionSource, indication = null) {
-                focusManager.clearFocus()
-            },
+        .background(Color.White)
+        .fillMaxSize()
+        .padding(horizontal = 16.dp)
+        .clickable(interactionSource = interactionSource, indication = null) {
+            focusManager.clearFocus()
+        },
         contentAlignment = Alignment.Center
     ) {
         Column(
@@ -99,7 +107,10 @@ fun LoginPage() {
                         userViewModel.login(username.text, password.text)
                     }
                 },
-                modifier = Modifier.padding(top = 24.dp).fillMaxWidth().height(44.dp),
+                modifier = Modifier
+                    .padding(top = 24.dp)
+                    .fillMaxWidth()
+                    .height(44.dp),
                 enabled = !isLoginButtonDisabled,
                 shape = RoundedCornerShape(50),
                 colors = ButtonDefaults.buttonColors(
@@ -117,7 +128,9 @@ fun LoginPage() {
             Spacer(modifier = Modifier.height(8.dp))
             OutlinedButton(
                 onClick = { navController.navigate(NavigationDestination.SignUp) },
-                modifier = Modifier.fillMaxWidth().height(44.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp),
                 shape = RoundedCornerShape(50),
                 border = BorderStroke(1.dp, Color.Black),
                 colors = ButtonDefaults.buttonColors(

--- a/android/app/src/main/java/com/goliath/emojihub/views/MainPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/MainPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -18,10 +17,6 @@ import com.goliath.emojihub.R
 fun MainPage() {
     val bottomNavigationController = LocalBottomNavigationController.current
     val currentRoute = bottomNavigationController.currentDestination.value
-
-    LaunchedEffect(Unit) {
-        bottomNavigationController.updateDestination(PageItem.Feed)
-    }
 
     Column(Modifier.fillMaxSize()) {
         Box(Modifier.weight(1f)) {


### PR DESCRIPTION
### 수정사항
- 이전 PR에서 잘못 수정한 부분이 있어 다시 올립니다..계정 전환 시에만 `BottomNavigationController`의 destination이 `Feed`가 되도록 수정했습니다