### PR TITLE
fix: navigate to login page after signup

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/views/SignUpPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/SignUpPage.kt
@@ -125,8 +125,8 @@ fun SignUpPage() {
                 title = "완료",
                 body = "계정 생성이 완료되었습니다.",
                 onDismissRequest = { showDialog = false },
-                confirm = { navController.navigateAsOrigin(NavigationDestination.Login)},
-                dismiss = {showDialog = false}
+                dismiss = { showDialog = false },
+                confirm = { navController.navigateAsOrigin(NavigationDestination.Login) }
             )
         }
     }


### PR DESCRIPTION
Changes:
- After successful signup navigate to login page when "완료" button is clicked
