### PR TITLE
fix video playback error for TransformVideoPage

### DIFF
--- a/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
+++ b/android/app/src/main/java/com/goliath/emojihub/views/TransformVideoPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
@@ -71,6 +72,13 @@ fun TransformVideoPage(
             setMediaItem(MediaItem.fromUri(viewModel.videoUri))
             repeatMode = Player.REPEAT_MODE_ALL
             prepare()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            exoPlayer.stop()
+            exoPlayer.release()
         }
     }
 


### PR DESCRIPTION
## 수정사항
* 이모지 영상 변환 후 TransformVideoPage를 벗어났을 때 백그라운드에서 계속 영상이 재생되는 오류를 수정하였습니다.