### PR TITLE
fix typo on github linguist glob pattern

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-pytorchvideo/* linguist-vendored
+pytorchvideo/** linguist-vendored
 pytorchvideo/pytorchvideo/data/hagrid.py linguist-vendored=false
 pytorchvideo/tutorials/accelerator/Use_PytorchVideo_Accelerator_Model_Zoo.ipynb linguist-vendored=false
 pytorchvideo/tutorials/video_classification_example/train_x3d_hagrid.py linguist-vendored=false


### PR DESCRIPTION
`pytorchvideo` 레포에서 포크해온 파일이 github linguist에 감지되는 것을 수정했습니다.